### PR TITLE
updated sideberry css for pinned tabs and tab groups

### DIFF
--- a/sideberry.css
+++ b/sideberry.css
@@ -5,3 +5,12 @@
 .t-box {
   padding-left: 4px;
 } 
+
+.NavigationBar .main-items {
+	padding-left: 6px;
+}
+
+.PinnedTabsBar .tab-wrapper {
+	position: relative;
+	padding-left: 6px;
+}


### PR DESCRIPTION
In this commit I added 2 css rules to align the navigation menu and the tab groups / pinned tabs